### PR TITLE
Fix schema resource file resolution under Python version < 3.9

### DIFF
--- a/csbschema/__init__.py
+++ b/csbschema/__init__.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 from csbschema import validators
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 
 B12_VERSION_3_0_0 = "3.0.0-2022-12"

--- a/csbschema/validators.py
+++ b/csbschema/validators.py
@@ -1,3 +1,6 @@
+import sys
+from importlib.abc import Traversable
+
 import mmap
 import json
 from pathlib import Path
@@ -25,6 +28,16 @@ def _validate_return(document: dict, errors: List[dict]) -> Tuple[bool, dict]:
         return False, {'document': document, 'errors': errors}
 
 
+def get_schema_file(resource_path: str) -> Union[Path, Traversable]:
+    if sys.version_info[0] == 3 and sys.version_info[1] < 9:
+        # Python version is less than 3.9, so use older method of resolving resource files
+        with resources.path('csbschema.data', resource_path) as schema_file:
+            return schema_file
+    else:
+        # Python version is >= 3.9, so use newer, non-deprecated resource resolution method
+        return resources.files('csbschema').joinpath(f"data/{resource_path}")
+
+
 def validate_b12_3_0_0(document_path: Union[Path, str]) -> Tuple[bool, dict]:
     """
     Validate B12 version 3.0.0 CSB data and metadata against JSON schema
@@ -36,7 +49,7 @@ def validate_b12_3_0_0(document_path: Union[Path, str]) -> Tuple[bool, dict]:
         is a dict representing the document that failed validation; and (2) 'errors' whose value is a list
         of dicts mapping JSON path elements to errors encountered at that element.
     """
-    schema_path = resources.files('csbschema').joinpath('data/CSB-schema-3_0_0-2022-12.json')
+    schema_path = get_schema_file('CSB-schema-3_0_0-2022-12.json')
     schema = None
     with schema_path.open('r') as f:
        schema = json.load(f)
@@ -107,7 +120,7 @@ def validate_b12_3_0_0bis(document_path: Union[Path, str]) -> Tuple[bool, dict]:
         is a dict representing the document that failed validation; and (2) 'errors' whose value is a list
         of dicts mapping JSON path elements to errors encountered at that element.
     """
-    schema_path = resources.files('csbschema').joinpath('data/CSB-schema-3_0_0bis-2022-12.json')
+    schema_path = get_schema_file('CSB-schema-3_0_0bis-2022-12.json')
     schema = None
     with schema_path.open('r') as f:
        schema = json.load(f)

--- a/csbschema/validators.py
+++ b/csbschema/validators.py
@@ -1,6 +1,4 @@
 import sys
-from importlib.abc import Traversable
-
 import mmap
 import json
 from pathlib import Path
@@ -28,14 +26,14 @@ def _validate_return(document: dict, errors: List[dict]) -> Tuple[bool, dict]:
         return False, {'document': document, 'errors': errors}
 
 
-def get_schema_file(resource_path: str) -> Union[Path, Traversable]:
+def get_schema_file(resource_path: str) -> Path:
     if sys.version_info[0] == 3 and sys.version_info[1] < 9:
         # Python version is less than 3.9, so use older method of resolving resource files
         with resources.path('csbschema.data', resource_path) as schema_file:
             return schema_file
     else:
         # Python version is >= 3.9, so use newer, non-deprecated resource resolution method
-        return resources.files('csbschema').joinpath(f"data/{resource_path}")
+        return Path(str(resources.files('csbschema').joinpath(f"data/{resource_path}")))
 
 
 def validate_b12_3_0_0(document_path: Union[Path, str]) -> Tuple[bool, dict]:


### PR DESCRIPTION
We were accidentally using a 3.9+ feature for finding resource files (i.e., schema files) within the package. This pull request allows `csbschema` to function in Python 3.8, rather than just Python 3.9 and above, which is the minimum version defined in `pyproject.toml`. Going forward, we should configure CI (e.g., using GH Actions) to automatically run tests for all supported Python versions (currently 3.8-3.11).