### PR TITLE
Explicitly set encoding to UTF-8 when opening schema files to fix bro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ CSB data file 'docs/IHO/b12_v3_2_0-BETA_example.json' successfully validated aga
 > Run `csbschema validate --help` for more information about validating against different versions of the schema.
 
 # Testing
-First, install csbschema with test dependencies:
+First, install test dependencies:
 ```shell
-$ pip install ".[test]"
+$ pip install -r requirements-test.txt
 ```
 
 Then run unit tests:

--- a/csbschema/__init__.py
+++ b/csbschema/__init__.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 from csbschema import validators
 
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 
 B12_VERSION_3_0_0_2023_03 = '3.0.0-2023-03'

--- a/csbschema/validators.py
+++ b/csbschema/validators.py
@@ -42,7 +42,7 @@ def _get_validator(schema_rsrc_name: str) -> Draft202012Validator:
     :return: Draft202012Validator instance
     """
     schema_path = _get_schema_file(schema_rsrc_name)
-    with schema_path.open('r') as f:
+    with schema_path.open('r', encoding='utf8') as f:
         schema = json.load(f)
     return jsonschema.Draft202012Validator(schema)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+flake8
+unittest-xml-reporting>=3.2.0
+lxml>=4.6.5
+pytest>=7.2.0
+pytest-cov>=4.0.0
+pytest-xdist>=3.0.2


### PR DESCRIPTION
…ken validation on platforms that don't use UTF-8 as the default encoding